### PR TITLE
Add a couple of regex rules for LaTeX documents

### DIFF
--- a/settings/spellchecker.json
+++ b/settings/spellchecker.json
@@ -10,7 +10,9 @@
     "ignoreRegExp": [
         "/\\\\(.*\\\\.(jpg|jpeg|png|md|gif|JPG|JPEG|PNG|MD|GIF)\\\\)/g",
         "/((http|https|ftp|git)\\\\S*)/g",
-        "/^(```\\\\s*)(\\\\w+)?(\\\\s*[\\\\w\\\\W]+?\\\\n*)(```\\\\s*)\\\\n*$/gm"
+        "/^(```\\\\s*)(\\\\w+)?(\\\\s*[\\\\w\\\\W]+?\\\\n*)(```\\\\s*)\\\\n*$/gm",
+        "/\\\\w*{.*?}/g",
+        "/\\~/g"
     ],
     "ignoreFileExtensions": [
         ".env"


### PR DESCRIPTION
`/\\\\w*{.*?}/g` stops the spell checker running on LaTeX commands featuring
arguments - for example `\cite{x}` and `\ref{x}`, as these commands often feature
abbreviated or joined words. The match before the closing "}" is minimised to
ensure adjacent commands don't prevent words between them from being ignored.

`/\\~/g` removes the "~" character, used for non-breaking space. This is often used
along with other commands, and triggers false positives. 
e.g.
`Some text here~\cite{refname}` will flag the word "here~" as being mis-spelled.
With this change, it will correctly check the word "here".
