### PR TITLE
Fixed LaTeX regex default ignores

### DIFF
--- a/src/features/SpellCheckerProvider.ts
+++ b/src/features/SpellCheckerProvider.ts
@@ -203,6 +203,20 @@ export default class SpellCheckerProvider implements vscode.CodeActionProvider
 			console.log( text );
 			console.log( '------------------------------------------' );
 		}
+		// remove LaTeX commands
+		text = text.replace( /\\\w*{.*?}/g, '' );
+		if( DEBUG )
+		{
+			console.log( text );
+			console.log( '------------------------------------------' );
+		}
+		// remove LaTeX non-breaking spaces
+		text = text.replace( /\\~/g, '' );
+		if( DEBUG )
+		{
+			console.log( text );
+			console.log( '------------------------------------------' );
+		}
 
 		let lastposition = 0;
 		let position = 0;


### PR DESCRIPTION
This is an update to #6, included within the typescript default file as required. I didn't want to push over the existing PR branch. I was unable to get VSCode working to test the patch, but the change should be in-keeping with the syntax of the other "ignore" rules.
