### PR TITLE
Fixed wrong/incomplete comment removal in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,47 +1,52 @@
 {
-    "name": "spellchecker",
-    "displayName": "SpellChecker",
-    "description": "Offline spell checker",
-    "version": "1.2.3",
-    "publisher": "swyphcosmo",
-    "engines": {
-        "vscode": "^1.0.0"
-    },
-    "categories": [
-        "Other"
+  "name": "spellchecker",
+  "displayName": "SpellChecker",
+  "description": "Offline spell checker",
+  "version": "1.2.3",
+  "publisher": "swyphcosmo",
+  "engines": {
+    "vscode": "^1.0.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "*"
+  ],
+  "main": "./out/src/extension",
+  "contributes": {
+    "commands": [
+      {
+        "command": "spellchecker.createSettingsFile",
+        "title": "Create Spell Checker Settings File"
+      },
+      {
+        "command": "spellchecker.showDocumentType",
+        "title": "Show documentType for Current File"
+      }
     ],
-    "activationEvents": [
-        "*"
-    ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "commands": [
-            {
-                "command": "spellchecker.createSettingsFile",
-                "title": "Create Spell Checker Settings File"
-            },
-            {
-                "command": "spellchecker.showDocumentType",
-                "title": "Show documentType for Current File"
-            }
-        ],
-        "keybindings": []
-    },
-    "scripts": {
-        "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-        "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install"
-    },
-    "devDependencies": {
-        "typescript": "^1.8.5",
-        "vscode": "^0.11.0"
-    },
-    "dependencies": {
-        "mkdirp": "^0.5.1"
-    },
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/swyphcosmo/vscode-spellchecker.git"
-    }
+    "keybindings": []
+  },
+  "scripts": {
+    "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
+    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
+  },
+  "devDependencies": {
+    "typescript": "^1.8.10",
+    "vscode": "^0.11.0"
+  },
+  "dependencies": {
+    "fs": "0.0.1-security",
+    "jsonminify": "^0.4.1",
+    "mkdirp": "^0.5.1",
+    "npm": "^4.0.2",
+    "path": "^0.12.7",
+    "typescript": "^1.8.10"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swyphcosmo/vscode-spellchecker.git"
+  }
 }

--- a/src/features/SpellCheckerProvider.ts
+++ b/src/features/SpellCheckerProvider.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 let mkdirp = require( 'mkdirp' );
 let sc = require( '../../../lib/hunspell-spellchecker/lib/index.js' );
+let jsonMinify = require( 'jsonminify' );
 
 // Toggle debug output
 let DEBUG:boolean = false;
@@ -642,14 +643,8 @@ export default class SpellCheckerProvider implements vscode.CodeActionProvider
 		{
 			let userSettingsFile: string = fs.readFileSync( userSettingsFilename, 'utf-8' );
 
-			// remove any comment lines
-			while( userSettingsFile[ 0 ] == '/' )
-			{
-				let userSettingsFileTokens: string[] = userSettingsFile.split( '\n' );
-				delete userSettingsFileTokens[ 0 ];
-				userSettingsFile = userSettingsFileTokens.join( '\n' );
-			}
-			return JSON.parse( userSettingsFile );
+			// parse and remove any comment lines in the settings file
+			return JSON.parse( jsonMinify( userSettingsFile) );
 		}
 		else
 			return null;


### PR DESCRIPTION
As discussed in issue #17, several people were unable to get the extension to work. As hinted by @TimMensch in the comments, I looked into the comment-removal stuff in the extension. 

The extension was only removing the commented head line in the settings file of vscode, leaving all other comments in.

I used [JSON.minify()](https://www.npmjs.com/package/jsonminify) to get around that issue and got the extension work without any issues left.

Please consider merging that piece of code.