### PR TITLE
Add support for Greek language (el_GR)

### DIFF
--- a/languages/el_GR README.txt
+++ b/languages/el_GR README.txt
@@ -1,0 +1,54 @@
+name      :  el_GR 0.9 version of the greek dictionary
+dd/mm/yyyy:  14/03/2015
+License   :  MPL 1.1/GPL 2.0/LGPL 2.1
+contact   :  Steve Stavropoulos
+URL       :  http://elspell.math.upatras.gr
+
+Added about 240259 new words in this release (courtesy of Γιώργος Γέγος, with the kind help of Nick Demou).
+
+ Steve Stavropoulos
+
+==================
+
+name      : el_GR (v.003) Enhanced Version
+dd/mm/yyyy: 08/02/2002
+License   : GNU GPL
+contact   : evris@source.gr
+URL       : ispell.source.gr
+----------------------------------------------- 
+This dictionary is based on greek wordlist and affixes used by ispell 
+(which based on older work of Mitalas and Seraskeris). Many thanks to 
+Voula Sanida (voulariba@source.gr) and Panayotis Vryonis (vrypan@yassou.net) 
+for their help in converting the affix rules and to all the people that
+contributed words to the vocabulary.
+Evripidis Papakostas (evris@source.gr)
+
+==================
+
+The new Licence:
+
+Version: MPL 1.1/GPL 2.0/LGPL 2.1
+
+The contents of this file are subject to the Mozilla Public License Version 
+1.1 (the "License"); you may not use this file except in compliance with 
+the License. You may obtain a copy of the License at 
+http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+for the specific language governing rights and limitations under the
+License.
+
+Alternatively, the contents of this file may be used under the terms of
+either the GNU General Public License Version 2 or later (the "GPL"), or
+the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+in which case the provisions of the GPL or the LGPL are applicable instead
+of those above. If you wish to allow use of your version of this file only
+under the terms of either the GPL or the LGPL, and not to allow others to
+use your version of this file under the terms of the MPL, indicate your
+decision by deleting the provisions above and replace them with the notice
+and other provisions required by the GPL or the LGPL. If you do not delete
+the provisions above, a recipient may use your version of this file under
+the terms of any one of the MPL, the GPL or the LGPL.
+
+

--- a/languages/el_GR.aff
+++ b/languages/el_GR.aff
@@ -1,0 +1,820 @@
+#  el_GR.aff 
+#  greek affix file
+#  for MySpell (pspell)
+#  GPL 
+#
+#
+#  LOG etc:
+#  --------
+#  Minor errors detected by Kevin Hendricks <kevin.hendricks@sympatico.ca>
+#  and corrected by me 08/06/02 (evris)
+#
+#  Fix the TRY order to be more useful. Added character mappings so the vowels
+#  that have the same pronunciation be closely related to each other. Added a
+#  replacement table to better describe the phonetic rules. 13/05/2004 (steve)
+#
+#  Added 59 REP rules and one more letter for the TRY (patch by Nick Demou)
+#
+#  Removed some REP rules and added some more (Nick Demou)
+#
+#  Steve Stavropoulos <steve@math.upatras.gr> 01/05/2004
+#
+#  Based on an older job :
+#  Papakostas Evripidis evris@source.gr ep@rocketmail.com 27/01/02
+#  Vryonis Panayotis    vrypan@yassou.net  27/01/02
+#
+#  Based on an older job :
+#  greek.aff file
+#  for ispell 
+#  Papakostas Evripidis evris@source.gr ep@rocketmail.com 1999
+#  
+#  Based on an older job :
+#  ellhnika.aff for Greek language by Μήταλας Γιάννης and Σερασκέρης Νίκος
+#  Καρλόβασι, Σάμος ,24-9-97  
+
+SET ISO8859-7
+# You are likely to forget the accent, so accented characters come first. If
+# you don't forget the accent, this order won't do any harm because it is higly
+# unlikely for a word that differs in one accented char plus some other mistake
+# to pop up in the possible suggestions (there has to be a closer match granted
+# that the word you are looking for exists).
+TRY άόίϊΐέήύϋΰώιηυωοεατνρσκμπλςγδθφβζξψχ
+
+MAP 5
+MAP αά
+MAP εέ
+MAP ωώοό
+MAP ηήύϋυιίϊΐ
+MAP σς
+
+# Do we have to put the accented characters in here or the MAP above is enough?
+# ANSWER: Looks like it is not! Maybe the map is only useful for the
+# suggestion order...
+#
+# Because of the automatic generation of the following REP there are some
+# combinations of letters that the greek language never uses, but I don't
+# think they will do any harm.
+REP 522
+REP α ά
+REP ά α
+REP γκ γγ
+REP γγ γκ
+REP πσ ψ
+REP ψ πσ
+REP κσ ξ
+REP ξ κσ
+REP άΰ άβ
+REP άΰ άυ
+REP άΰ άϋ
+REP άΰ αΰ
+REP άΰ αβ
+REP άΰ αυ
+REP άΰ αϋ
+REP άΰ αύ
+REP άβ άυ
+REP άβ άϋ
+REP άβ αΰ
+REP άβ αβ
+REP άβ αυ
+REP άβ αϋ
+REP άβ αύ
+REP άυ άβ
+REP άυ άϋ
+REP άυ αΰ
+REP άυ αβ
+REP άυ αυ
+REP άυ αϋ
+REP άυ αύ
+REP άϋ άβ
+REP άϋ άυ
+REP άϋ αΰ
+REP άϋ αβ
+REP άϋ αυ
+REP άϋ αϋ
+REP άϋ αύ
+REP άύ άβ
+REP άύ άυ
+REP άύ άϋ
+REP άύ αΰ
+REP άύ αβ
+REP άύ αυ
+REP άύ αϋ
+REP άύ αύ
+REP αΰ άβ
+REP αΰ άυ
+REP αΰ άϋ
+REP αΰ αβ
+REP αΰ αυ
+REP αΰ αϋ
+REP αΰ αύ
+REP αβ άβ
+REP αβ άυ
+REP αβ άϋ
+REP αβ αΰ
+REP αβ αυ
+REP αβ αϋ
+REP αβ αύ
+REP αυ άβ
+REP αυ άυ
+REP αυ άϋ
+REP αυ αΰ
+REP αυ αβ
+REP αυ αϋ
+REP αυ αύ
+REP αϋ άβ
+REP αϋ άυ
+REP αϋ άϋ
+REP αϋ αΰ
+REP αϋ αβ
+REP αϋ αυ
+REP αϋ αύ
+REP αύ άβ
+REP αύ άυ
+REP αύ άϋ
+REP αύ αΰ
+REP αύ αβ
+REP αύ αυ
+REP αύ αϋ
+REP ι ί
+REP ί ι
+REP ι ϊ
+REP ϊ ι
+REP ι ΐ
+REP ΐ ι
+REP ι η
+REP η ι
+REP ι ή
+REP ή ι
+REP ι υ
+REP υ ι
+REP ι ύ
+REP ύ ι
+REP ι ϋ
+REP ϋ ι
+REP ι ΰ
+REP ΰ ι
+REP ί ϊ
+REP ϊ ί
+REP ί ΐ
+REP ΐ ί
+REP ί η
+REP η ί
+REP ί ή
+REP ή ί
+REP ί υ
+REP υ ί
+REP ί ύ
+REP ύ ί
+REP ί ϋ
+REP ϋ ί
+REP ί ΰ
+REP ΰ ί
+REP ϊ ΐ
+REP ΐ ϊ
+REP ϊ η
+REP η ϊ
+REP ϊ ή
+REP ή ϊ
+REP ϊ υ
+REP υ ϊ
+REP ϊ ύ
+REP ύ ϊ
+REP ϊ ϋ
+REP ϋ ϊ
+REP ϊ ΰ
+REP ΰ ϊ
+REP ΐ η
+REP η ΐ
+REP ΐ ή
+REP ή ΐ
+REP ΐ υ
+REP υ ΐ
+REP ΐ ύ
+REP ύ ΐ
+REP ΐ ϋ
+REP ϋ ΐ
+REP ΐ ΰ
+REP ΰ ΐ
+REP η ή
+REP ή η
+REP η υ
+REP υ η
+REP η ύ
+REP ύ η
+REP η ϋ
+REP ϋ η
+REP η ΰ
+REP ΰ η
+REP ή υ
+REP υ ή
+REP ή ύ
+REP ύ ή
+REP ή ϋ
+REP ϋ ή
+REP ή ΰ
+REP ΰ ή
+REP υ ύ
+REP ύ υ
+REP υ ϋ
+REP ϋ υ
+REP υ ΰ
+REP ΰ υ
+REP ύ ϋ
+REP ϋ ύ
+REP ύ ΰ
+REP ΰ ύ
+REP ϋ ΰ
+REP ΰ ϋ
+REP ο ό
+REP ό ο
+REP ο ω
+REP ω ο
+REP ο ώ
+REP ώ ο
+REP ό ω
+REP ω ό
+REP ό ώ
+REP ώ ό
+REP ω ώ
+REP ώ ω
+REP έΰ έβ
+REP έΰ έυ
+REP έΰ έϋ
+REP έΰ εΰ
+REP έΰ εβ
+REP έΰ ευ
+REP έΰ εϋ
+REP έΰ εύ
+REP έβ έυ
+REP έβ έϋ
+REP έβ εΰ
+REP έβ εβ
+REP έβ ευ
+REP έβ εϋ
+REP έβ εύ
+REP έυ έβ
+REP έυ έϋ
+REP έυ εΰ
+REP έυ εβ
+REP έυ ευ
+REP έυ εϋ
+REP έυ εύ
+REP έϋ έβ
+REP έϋ έυ
+REP έϋ εΰ
+REP έϋ εβ
+REP έϋ ευ
+REP έϋ εϋ
+REP έϋ εύ
+REP έύ έβ
+REP έύ έυ
+REP έύ έϋ
+REP έύ εΰ
+REP έύ εβ
+REP έύ ευ
+REP έύ εϋ
+REP έύ εύ
+REP εΰ έβ
+REP εΰ έυ
+REP εΰ έϋ
+REP εΰ εβ
+REP εΰ ευ
+REP εΰ εϋ
+REP εΰ εύ
+REP εβ έβ
+REP εβ έυ
+REP εβ έϋ
+REP εβ εΰ
+REP εβ ευ
+REP εβ εϋ
+REP εβ εύ
+REP ευ έβ
+REP ευ έυ
+REP ευ έϋ
+REP ευ εΰ
+REP ευ εβ
+REP ευ εϋ
+REP ευ εύ
+REP εϋ έβ
+REP εϋ έυ
+REP εϋ έϋ
+REP εϋ εΰ
+REP εϋ εβ
+REP εϋ ευ
+REP εϋ εύ
+REP εύ έβ
+REP εύ έυ
+REP εύ έϋ
+REP εύ εΰ
+REP εύ εβ
+REP εύ ευ
+REP εύ εϋ
+REP έΐ έι
+REP έΐ έϊ
+REP έΐ εΐ
+REP έΐ εί
+REP έΐ ει
+REP έΐ εϊ
+REP έί έι
+REP έί έϊ
+REP έί εΐ
+REP έί εί
+REP έί ει
+REP έί εϊ
+REP έι έϊ
+REP έι εΐ
+REP έι εί
+REP έι ει
+REP έι εϊ
+REP έϊ έι
+REP έϊ εΐ
+REP έϊ εί
+REP έϊ ει
+REP έϊ εϊ
+REP εΐ έι
+REP εΐ έϊ
+REP εΐ εί
+REP εΐ ει
+REP εΐ εϊ
+REP εί έι
+REP εί έϊ
+REP εί εΐ
+REP εί ει
+REP εί εϊ
+REP ει έι
+REP ει έϊ
+REP ει εΐ
+REP ει εί
+REP ει εϊ
+REP εϊ έι
+REP εϊ έϊ
+REP εϊ εΐ
+REP εϊ εί
+REP εϊ ει
+REP άΐ άι
+REP άΐ άϊ
+REP άΐ αΐ
+REP άΐ αί
+REP άΐ αι
+REP άΐ αϊ
+REP άί άι
+REP άί άϊ
+REP άί αΐ
+REP άί αί
+REP άί αι
+REP άί αϊ
+REP άι άϊ
+REP άι αΐ
+REP άι αί
+REP άι αι
+REP άι αϊ
+REP άϊ άι
+REP άϊ αΐ
+REP άϊ αί
+REP άϊ αι
+REP άϊ αϊ
+REP αΐ άι
+REP αΐ άϊ
+REP αΐ αί
+REP αΐ αι
+REP αΐ αϊ
+REP αί άι
+REP αί άϊ
+REP αί αΐ
+REP αί αι
+REP αί αϊ
+REP αι άι
+REP αι άϊ
+REP αι αΐ
+REP αι αί
+REP αι αϊ
+REP αϊ άι
+REP αϊ άϊ
+REP αϊ αΐ
+REP αϊ αί
+REP αϊ αι
+REP άί έ
+REP άί ε
+REP άι έ
+REP άι ε
+REP έ άι
+REP έ αΐ
+REP έ αί
+REP έ αι
+REP έ αϊ
+REP έ ε
+REP αΐ έ
+REP αΐ ε
+REP αί έ
+REP αί ε
+REP αι έ
+REP αι ε
+REP αϊ έ
+REP αϊ ε
+REP ε άι
+REP ε έ
+REP ε αΐ
+REP ε αί
+REP ε αι
+REP ε αϊ
+REP ή ει
+REP ή οι
+REP ί ει
+REP ί οι
+REP εί η
+REP εί ι
+REP εί οι
+REP εί υ
+REP εί ή
+REP εί ί
+REP εί οί
+REP εί ύ
+REP ει ή
+REP ει ί
+REP ει η
+REP ει ι
+REP ει οί
+REP ει οι
+REP ει υ
+REP ει ύ
+REP η εί
+REP η ει
+REP η οί
+REP η οι
+REP ηβ ηυ
+REP ηυ ηβ
+REP ι εί
+REP ι ει
+REP ι οί
+REP ι οι
+REP κ κκ
+REP κκ κ
+REP λ λλ
+REP λλ λ
+REP μ μμ
+REP μμ μ
+REP οί ει
+REP οί η
+REP οί ι
+REP οί υ
+REP οι ή
+REP οι ί
+REP οι εί
+REP οι ει
+REP οι η
+REP οι ι
+REP οι υ
+REP οι ύ
+REP π ππ
+REP ππ π
+REP ρ ρρ
+REP ρρ ρ
+REP σ σσ
+REP σσ σ
+REP τ ττ
+REP ττ τ
+REP υ εί
+REP υ ει
+REP υ οί
+REP υ οι
+REP ύ ει
+REP ύ οι
+REP αυ αφ
+REP άυ αφ
+REP αύ αφ
+REP αυ άφ
+REP άυ άφ
+REP αύ άφ
+REP αφ αυ
+REP άφ αυ
+REP αφ αύ
+REP άφ αύ
+REP άφ αφ
+REP αφ άφ
+REP έι η
+REP έι ή
+REP έι ι
+REP έι ί
+REP ει ϊ
+REP έι ϊ
+REP εί ϊ
+REP ει ΐ
+REP έι ΐ
+REP εί ΐ
+REP έι οι
+REP έι οί
+REP έι υ
+REP έι ύ
+REP ει ϋ
+REP έι ϋ
+REP εί ϋ
+REP ει ΰ
+REP έι ΰ
+REP εί ΰ
+REP ευ εφ
+REP έυ εφ
+REP εύ εφ
+REP ευ έφ
+REP έυ έφ
+REP εύ έφ
+REP εφ ευ
+REP έφ ευ
+REP εφ εύ
+REP έφ εύ
+REP έφ εφ
+REP εφ έφ
+REP ή εί
+REP ή οί
+REP ϊ ει
+REP ΐ ει
+REP ί εί
+REP ϊ εί
+REP ΐ εί
+REP ϊ οι
+REP ΐ οι
+REP ί οί
+REP ϊ οί
+REP ΐ οί
+REP όι ει
+REP όι εί
+REP οί εί
+REP όι η
+REP όι ή
+REP οί ή
+REP όι ι
+REP όι ί
+REP οί ί
+REP οι ϊ
+REP όι ϊ
+REP οί ϊ
+REP οι ΐ
+REP όι ΐ
+REP οί ΐ
+REP όι οι
+REP οί οι
+REP οι οί
+REP όι οί
+REP όι υ
+REP όι ύ
+REP οί ύ
+REP οι ϋ
+REP όι ϋ
+REP οί ϋ
+REP οι ΰ
+REP όι ΰ
+REP οί ΰ
+REP όυ ου
+REP ού ου
+REP ου ού
+REP όυ ού
+REP ϋ ει
+REP ΰ ει
+REP ύ εί
+REP ϋ εί
+REP ΰ εί
+REP ϋ οι
+REP ΰ οι
+REP ύ οί
+REP ϋ οί
+REP ΰ οί
+
+# prefix rules
+
+
+PFX A Y 1
+PFX A   0     α         .       # βάσιμος > αβάσιμος
+
+PFX B Y 1
+PFX B   0     ξανα      .       # ζητώ > ξαναζητώ
+
+PFX C Y 1
+PFX C   0     απο       .       # σύνθεση > αποσύνθεση
+
+PFX D Y 1
+PFX D   0     κατα      .       # στροφή > καταστροφή
+
+PFX E Y 1
+PFX E   0     παρα      .       # βλέπω > παραβλέπω
+
+                                                     
+# suffix rules
+
+SFX F Y 4
+SFX F ώ     ά          .    # αγαπώ > αγαπά
+SFX F ός    ά          .    # καλός > καλά 
+SFX F ό     ά          .    # βουνό > βουνά      
+SFX F άς    ά          .    # σφουγγαράς > σφουγγαρά
+
+SFX G Y 7
+SFX G ώ     άς         .    # αγαπώ > αγαπάς 
+SFX G 0     ς          ά    # καρδιά > καρδιάς
+SFX G ός    ού         .    # ουρανός > ουρανού
+SFX G ό     ού         .    # βουνό > βουνού
+SFX G ούς   ού         .    # παππούς > παππού 
+SFX G ω     εις        .    # δένω > δένεις 
+SFX G η     εις        .    # σκέψη > σκέψεις
+
+SFX H Y 3 
+SFX H 0     ς          [ώω]     # Αργυρώ > Αργυρώς  Δέσπω > Δέσπως
+SFX H ός    ώς         .        # καλός > καλώς   τελευταίος τελευταίως
+SFX H ής    ώς         .        # # συνεχής > συνεχώς
+
+SFX I Y 5 
+SFX I ώ     είς        .          # αγαπηθώ > αγαπηθείς
+SFX I ος    α          .          # ωραίος > ωραία 
+SFX I ο     α          .          # βιβλίο > βιβλία  
+SFX I ης    α          .          # ζηλιάρης > ζηλιάρα
+SFX I ας    α          .          # αγώνας > αγώνα
+ 
+SFX J Y 5 
+SFX J ώ     εί         .          # αγαπηθώ > αγαπηθεί
+SFX J ός    έ          .          # ουρανός > ουρανέ
+SFX J ές    έ          .          # καφές > καφέ 
+SFX J ύς    ιούς       .          # βαθύς > βαθιούς
+SFX J ω     οντας      .          # δένω > δένοντας
+	 
+SFX K Y 4 
+SFX K ώ    ούμε        .           # αγαπώ > αγαπούμε
+SFX K ός   οί          .           # ουρανός > ουρανοί
+SFX K ές   έδες        .           # καφές > καφέδες
+SFX K 0    ς           η           # νίκη > νίκης
+
+SFX L Y 5 
+SFX L ός   ών          .           # ουρανός > ουρανών 
+SFX L ής   ών          .           # νικητής > νικητών 
+SFX L ά    ών          .           # καρδιά > καρδιών
+SFX L ή    ών          .           # ψυχή > ψυχών
+SFX L ό    ών          .           # βουνό > βουνών
+
+SFX M Y 4 
+SFX M ώ    ούν         .            # αγαπώ > αγαπούν
+SFX M ός   ούς         .            # ουρανός > ουρανούς
+SFX M ώς   ώτων        .            # καθεστώς > καθεστώτων
+SFX M ί    ιού         .            # πουλί > πουλιού 
+
+SFX N Y 5
+SFX N ούς  ούδων       .             # παππούς > παππούδων
+SFX N ας   ες          .             # αγώνας > αγώνες
+SFX N α    ες          .             # ώρα > ώρες
+SFX N η    ες          .             # νίκη > νίκες 
+SFX N ης   ες          .             # ναύτης > ναύτες
+
+SFX O Y 5
+SFX O ώ    άμε         .            # αγαπώ > αγαπάμε
+SFX O ός   ιά          .            # γλυκός > γλυκιά
+SFX O ής   ιά          .            # σταχτής > σταχτιά 
+SFX O ί    ιά          .            # πουλί > πουλιά
+SFX O ύς   ιά          .            # βαθύς > βαθιά 
+
+SFX P Y 4
+SFX P ώ    άτε         .            # αγαπώ > αγαπάτε
+SFX P ός   ότος        .            # γεγονός > γεγονότος
+SFX P ω    ετε         .            # δένω > δένετε
+SFX P η    εως         .            # σκέψη > σκέψεως
+
+SFX Q Y 5
+SFX Q ώ    άστε        .            # λυπώ > λυπάστε
+SFX Q ας   ων          .            # αγώνας > αγώνων 
+SFX Q ος   ων          .            # δρόμος > δρόμων
+SFX Q ο    ων          .            # σίδερο > σίδερων
+SFX Q ύς   ύ           .            # βαθύς > βαθύ
+
+	 
+SFX R Y 4
+SFX R ώ    ιέμαι       .            # αγαπώ > αγαπιέμαι
+SFX R ής   άδες        .            # πραματευτής > πραματευτάδες
+SFX R άς   άδες        .            # σφουγγαράς > σφουγγαράδες
+SFX R ω    ομαι        .            # δένω > δένομαι
+
+	 
+SFX S Y 4
+SFX S ώ    ιέσαι       .            # αγαπώ > αγαπιέσαι
+SFX S ής   άδων        .            # πραματευτής > πραματευτάδων
+SFX S άς   άδων        .            # σφουγγαράς > σφουγγαράδων
+SFX S ω    εσαι        .            # δένω > δένεσαι
+
+SFX T Y 4
+SFX T ώ   άν           .             # αγαπώ > αγαπάν 
+SFX T ός  ότα          .             # γεγονός > γεγονότα
+SFX T ω   ουν          .             # δένω > δένουν
+SFX T ας  ατα          .             # κρέας > κρέατα
+
+
+SFX U Y 4
+SFX U ώ     ιέται     .              # αγαπώ > αγαπιέται 
+SFX U ής    ήδες      .              # μπαλωματής > μπαλωματήδες
+SFX U ί     ιών       .              # πουλί > πουλιών
+SFX U ύς    ιών       .              # βαθύς > βαθιών
+
+	 
+SFX V Y 5
+SFX V ώ     ιέστε     .              # αγαπώ > αγαπιέστε
+SFX V ούς   ούδες     .              # παππούς > παππούδες
+SFX V ής    ί         .              # σταχτής > σταχτί
+SFX V ω     εστε      .              # δένω > δένεστε
+SFX V 0     τα        μα             # κύμα > κύματα
+
+SFX W Y 5
+SFX W ώ     ιούνται   .              # αγαπώ > αγαπιούνται
+SFX W ώς    ώτα       .              # καθεστώς > καθεστώτα
+SFX W ω     ονται     .              # δένω > δένονται
+SFX W 0     τος       μα             # κύμα > κύματος
+SFX W 0     ς         ή              # ψυχή > ψυχής
+
+SFX X Y 5
+SFX X ώ   ιόμουν      .               # αγαπώ > αγαπιόμουν
+SFX X ός  ή           .               # καλός > καλή 
+SFX X ος  η           .               # δάσος > δάση 
+SFX X ής  ή           .               # νικητής > νικητή 
+SFX X ης  η           .               # ναύτης > ναύτη
+
+SFX Y Y 4
+SFX Y ώ       ιόσουν  .               # αγαπώ > αγαπιόσουν
+SFX Y όμουν   όσουν   .               # δενόμουν > δενόσουν 
+SFX Y ω       ουμε    .               # δένω > δένουμε
+SFX Y η       εων     .               # σκέψη > σκέψεων
+
+
+SFX Z Y 3
+SFX Z ώ       ιόταν   .               # αγαπώ > αγαπιόταν
+SFX Z μουν   ταν      όμουν           # δενόμουν > δενόταν 
+SFX Z ς      δων      ές              # καφές > καφέδων
+
+SFX a Y 4
+SFX a ώ     ιόμαστε      .            # αγαπώ > αγαπιόμαστε
+SFX a ός    ό            .            # καλός > καλό
+SFX a ω     αμε          .            # δένω > δέναμε
+SFX a 0     με           α            # αγαπούσα > αγαπούσαμε
+
+	 
+SFX b Y 4
+SFX b ώ    ιόσαστε     .               # αγαπώ > αγαπιόσαστε
+SFX b ω    ατε         .               # δένω > δένατε
+SFX b με   τε          αμε             # αγαπήσαμε > αγαπήσατε
+SFX b 0    τε          α               # αγαπούσα > αγαπούσατε
+
+SFX c Y 3
+SFX c ώ      ιόνταν    .               # αγαπώ > αγαπιόνταν
+SFX c όμουν  όνταν     .               # θυμόμουν > θυμόνταν
+SFX c ω      ονταν     .               # δένω > δένονταν
+
+SFX d Y 4
+SFX d ώ      ιούνταν     .             # αγαπώ > αγαπιούνταν
+SFX d ω      ου          .             # δένω > δένου
+SFX d 0      υ           ο             # σίδερο > σίδερου
+SFX d ς      υ           ος            # δρόμος > δρόμου
+
+SFX e Y 4
+SFX e  ώ    ούνται   .                 # λυπώ > λυπούνται
+SFX e  ω    ε        .                 # δένω > δένε
+SFX e  ος   ε        .                 # δρόμος > δρόμε
+SFX e  α    ε        .                 # αγαπούσα > αγαπούσε
+
+SFX f Y 3
+SFX f ώ   άσαι   .                     # λυπώ > λυπάσαι
+SFX f ί   ιού    .                     # πουλί > πουλιού
+SFX f ς   δες    ης                    # νοικοκύρης > νοικοκύρηδες
+
+SFX g Y 4
+SFX g ώ          άται        .         # λυπώ > λυπάται
+SFX g ός         ότων        .         # γεγονός γεγονότων
+SFX g ης         ηδων        .         # νοικοκύρης > νοικοκύρηδων
+SFX g α          αν          .         # αγαπούσα > αγαπούσαν
+
+SFX h Y 4
+SFX h ώ          ούμαστε     .         # λυπώ > λυπούμαστε
+SFX h ώς         ώτος        .         # καθεστώς > καθεστώτος
+SFX h όμουν      όμαστε      .         # δενόμουν > δενόμαστε
+SFX h α          ας          .         # ώρα > ώρας
+
+SFX i Y 4
+SFX i ώ          ώντας       .         # αγαπώ > αγαπώντας
+SFX i ής         ές          .         # νικητής > νικητές
+SFX i ά          ές          .         # καρδιά > καρδιές
+SFX i ή          ές          .         # ψυχή > ψυχές
+
+SFX j Y 3
+SFX j ης         ικο         .         # ζηλιάρης > ζηλιάρικο
+SFX j ω          τε          .         # δέσω > δέστε
+SFX j ος         ους         .         # δρόμος > δρόμους
+
+SFX k Y 3
+SFX k ω          εται        .         # δένω > δένεται
+SFX k ος         οι          .         # δρόμος > δρόμοι
+SFX k ας         ατος        .         # κρέας > κρέατος
+
+SFX l Y 4
+SFX l υ          ια          .         # βράδυ > βράδια
+SFX l ι          ια          .         # καλοκαίρι > καλοκαίρια
+SFX l ώ          ούμαι       .         # λυπώ > λυπούμαι
+SFX l ής         ήδων        .         # μπαλωματής > μπαλωματήδων
+
+SFX m Y 3
+SFX m ώ          άει         .         # αγαπώ > αγαπάει
+SFX m όμουν      όσαστε      .         # δενόμουν > δενόσαστε
+SFX m ω          ει          .         # δένω > δένει  
+
+SFX n Y 3
+SFX n ύς         ιοί         .        # βαθύς > βαθιοί 
+SFX n ώ          είτε        .        # αγαπηθώ > αγαπηθείτε
+SFX n ος         ο           .        # δρόμος > δρόμο


### PR DESCRIPTION
Seems like this is how it works.

The problem is that I don't know how to test it as I have no experience with the vscode extension system.

I ran npm install on the directory, then used vscode's debug mode and put `"spellchecker.language": "el_GR"` on my settings file. Then I tried typing both english and greek but it was not able to correct either of those languages.

Note that things work fine when I enable the extension from the Marketplace so I suppose I did something wrong on my debug process. 