### PR TITLE
Remove a fixed issue from the known issues section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following settings can be changed:
 
 * `spellchecker.language`: supported languages are:
 	* English (`"en_US"` or `"en_GB-ise"`)
+	* French (`"fr"`)
 	* Greek (`"el_GR"`)
 	* Spanish (`"es_ANY"`)
 * `spellchecker.ignoreWordsList`: an array of strings that contain the words that will not be checked by the spell checker

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ This same document was checked on a newer computer ( Razer Blade Stealth vs. 4 y
 
 ## Known Issues
 
-* Only U.S. English supported
 * Entire file is rechecked with each update
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ You can configure the operation of this extension by editing settings in `File >
 
 The following settings can be changed:
 
-* `spellchecker.language`: supported languages are English (`"en_US"` or `"en_GB-ise"`) and Spanish (`"es_ANY"`).
+* `spellchecker.language`: supported languages are:
+	* English (`"en_US"` or `"en_GB-ise"`)
+	* Greek (`"el_GR"`)
+	* Spanish (`"es_ANY"`)
 * `spellchecker.ignoreWordsList`: an array of strings that contain the words that will not be checked by the spell checker
 * `spellchecker.documentTypes`: an array of strings that limit the document types that this extension will check. Default document types are `"markdown"`, `"latex"`, and `"plaintext"`.
 * `spellchecker.ignoreFileExtensions`: an array of file extensions that will not be spell checked

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
                 "spellchecker.language": {
                     "type": "string",
                     "default": "en_US",
-                    "description": "Dictionary language. Currently supported: 'en_US', 'en_GB-ise', or 'es_ANY'."
+                    "description": "Dictionary language. Currently supported: 'en_US', 'en_GB-ise', 'fr', 'el_GR', or 'es_ANY'."
                 },
                 "spellchecker.documentTypes": {
                     "type": "array",


### PR DESCRIPTION
Since this extension now supports two dialects of English as well as Spanish and Greek, the known issue of "Only U.S. English supported" can be removed.

Since Greek was omitted from the README when it was added, this PR also adds an entry for that.

This also adds the undocumented languages to the `package.json`.