### PR TITLE
Trim trailing whitespace from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Current Version](http://vsmarketplacebadge.apphb.com/version/swyphcosmo.spellchecker.svg)](https://marketplace.visualstudio.com/items?itemName=swyphcosmo.spellchecker)
 [![Install Count](http://vsmarketplacebadge.apphb.com/installs/swyphcosmo.spellchecker.svg)](https://marketplace.visualstudio.com/items?itemName=swyphcosmo.spellchecker)
 
-## Description 
+## Description
 
 This extension is a spell checker that uses a local dictionary for offline usage. [hunspell-spellchecker](https://github.com/GitbookIO/hunspell-spellchecker) is used to load hunspell formatted dictionaries. Errors are highlighted, and hovering over them will show possible suggestions. The `suggest` function was modified according to [https://github.com/GitbookIO/hunspell-spellchecker/pull/7] to speed up word suggestions.
 
@@ -13,7 +13,7 @@ This extension can be found on the [VSCode Marketplace](https://marketplace.visu
 
 Once errors are highlighted, there are several ways to view word suggestions.
 
-Hover over the error: 
+Hover over the error:
 
 ![Hover](images/hover-view.png)
 
@@ -21,7 +21,7 @@ By pressing `F8` to step through errors:
 
 ![Error View](images/error-view.png)
 
-You can correct the error by clicking on the Quick Fix (light bulb) icon. 
+You can correct the error by clicking on the Quick Fix (light bulb) icon.
 
 ![Quick Fix](images/making-corrections.gif)
 
@@ -45,13 +45,13 @@ Additional sections are already removed from files, including:
 
 * YAML header for [pandoc](http://pandoc.org/) settings
 * `&nbsp;`
-* Pandoc citations 
+* Pandoc citations
 * Inline code blocks
 * Email addresses
 
 ## Benchmarks (sort of)
 
-A 397-line document was used to test the functionality. This was a conference paper that I recently wrote using Pandoc (citeproc and crossref). Simple space separation results in 5134 words. Here are some of the processing times as functionality was added. These were measured using `new Date().getTime()` so results were not consistent.  
+A 397-line document was used to test the functionality. This was a conference paper that I recently wrote using Pandoc (citeproc and crossref). Simple space separation results in 5134 words. Here are some of the processing times as functionality was added. These were measured using `new Date().getTime()` so results were not consistent.
 
 * Initial test: 1.577 minutes
 * Added suggestion dictionary for suggestions that have already been processed: 1.0507 minutes
@@ -80,7 +80,7 @@ This same document was checked on a newer computer ( Razer Blade Stealth vs. 4 y
 * `v1.2.11`:
 	* Increased icon size.
 * `v1.2.10`:
-	* Added settings to package.json so that VSCode doesn't give warnings when editing `settings.json`. 
+	* Added settings to package.json so that VSCode doesn't give warnings when editing `settings.json`.
 	* Workspace settings are now included in `.vscode/settings.json`. Previous `.vscode/spellchecker.json` will be migrated with the option to delete.
 	* Removed 'CreateConfigurationFile' action because configuration can now be handled though `File > Preferences > Settings`.
 	* Added command to set language.
@@ -139,7 +139,7 @@ This same document was checked on a newer computer ( Razer Blade Stealth vs. 4 y
 
 ## Acknowledgements
 
-Big thanks to Sean McBreen for [Spell and Grammar Check](https://github.com/Microsoft/vscode-spell-check). 
+Big thanks to Sean McBreen for [Spell and Grammar Check](https://github.com/Microsoft/vscode-spell-check).
 
 ## License
 


### PR DESCRIPTION
While this doesn't make a different to the rendering, it avoids future diff noise as many people have whitespace trimming configured in their editors.