### PR TITLE
Fix Language Detection

### DIFF
--- a/src/features/SpellCheckerProvider.ts
+++ b/src/features/SpellCheckerProvider.ts
@@ -140,7 +140,7 @@ export default class SpellCheckerProvider implements vscode.CodeActionProvider {
 		});
 
 		vscode.window.showQuickPick(options, qpOptions).then(val => {
-			let language = val.match(/\(.*\)/g)[0];
+			let language = val.match(/\(\S*\)/g)[0];
 			language = language.substring(1, language.length - 1);
 			this.setLanguage(language);
 		});


### PR DESCRIPTION
# Summary

* Some language descriptions include text in parens so `.*` in a regex is greedy and grabs all of the text. e.g. `English UK (-ize/Oxford) (en_GB-ize)` would match `(-ize/Oxford) (en_GB-ize)` instead of the desired `(en_GB-ize)`
* Language files shouldn't have spaces in them so match any white space characters instead.