### PR TITLE
Ignore Files by Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This same document was checked on a newer computer ( Razer Blade Stealth vs. 4 y
 	* Added English GB-ize/Oxford dictionary (#75) Thanks [kuro68k](https://github.com/kuro68k)
 	* Suggestion severity can be selected from a dropdown (addresses #71)
 	* Updated Spanish dictionary which contained HTML headers in error
+	* Add user setting for ignoring file by name (addresses #72)
 * `v1.3.0`:
 	* Convert icon from svg to png.
 	* Emit warnings instead of errors. Added new setting to override to error (#62)

--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
                     "default": [],
                     "description": "Array of file extensions that will not be spell checked."
                 },
+                "spellchecker.ignoreFilenames": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Array of filenames that will not be spell checked."
+                },
                 "spellchecker.checkInterval": {
                     "type": "integer",
                     "default": 5000,

--- a/src/features/SpellCheckerProvider.ts
+++ b/src/features/SpellCheckerProvider.ts
@@ -16,6 +16,7 @@ interface SpellSettings {
 	documentTypes: string[];
 	ignoreRegExp: string[];
 	ignoreFileExtensions: string[];
+	ignoreFilenames: string[];
 	checkInterval: number;
 	suggestionSeverity: string;
 }
@@ -157,6 +158,11 @@ export default class SpellCheckerProvider implements vscode.CodeActionProvider {
 			return;
 		}
 
+		// Is this a filename that should be ignored?
+		if (this.settings.ignoreFilenames.indexOf(path.basename(event.document.fileName)) >= 0) {
+			return
+		}
+
 		// If checkInterval is negative, the document will not be automatically checked
 		if (this.settings.checkInterval < 0) {
 			return;
@@ -217,6 +223,11 @@ export default class SpellCheckerProvider implements vscode.CodeActionProvider {
 		// Is this a file extension that we should ignore?
 		if (this.settings.ignoreFileExtensions.indexOf(path.extname(textDocument.fileName)) >= 0) {
 			return;
+		}
+
+		// Is this a filename that should be ignored?
+		if (this.settings.ignoreFilenames.indexOf(path.basename(textDocument.fileName)) >= 0) {
+			return
 		}
 
 		let startTime = new Date().getTime();
@@ -752,6 +763,7 @@ export default class SpellCheckerProvider implements vscode.CodeActionProvider {
 			documentTypes: ['markdown', 'latex', 'plaintext'],
 			ignoreRegExp: [],
 			ignoreFileExtensions: [],
+			ignoreFilenames: [],
 			checkInterval: 5000,
 			suggestionSeverity: "Warning",
 		};


### PR DESCRIPTION
# Summary

* There are some cases where a user might want to ignore specific filenames without ignoring all extensions and file types.
* Closes #72 